### PR TITLE
Maholder label dbs

### DIFF
--- a/controllers/cloud.redhat.com/providers/inmemorydb/redis.go
+++ b/controllers/cloud.redhat.com/providers/inmemorydb/redis.go
@@ -11,6 +11,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rc "github.com/RedHatInsights/rhc-osdk-utils/resourceCache"
 	"github.com/RedHatInsights/rhc-osdk-utils/utils"
@@ -98,7 +99,7 @@ func makeLocalRedis(o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodeP
 
 	labeler(dd)
 
-	// dd.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+	dd.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 	dd.Spec.Template.ObjectMeta.Labels = labels
 	dd.Spec.Replicas = &oneReplica
 

--- a/tests/kuttl/test-local-db-redis/01-assert.yaml
+++ b/tests/kuttl/test-local-db-redis/01-assert.yaml
@@ -2,20 +2,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: app-a-db
+  name: app-a-redis
   namespace: test-local-db-redis
 spec:
   template:
+    metadata:
+      labels:
+        service: redis
     spec:
-      metadata:
-        labels:
-          service: redis
       containers:
-        - image: quay.io/cloudservices/redis:3.2.3-alpine
-          resources:
-            limits:
-              cpu: 1800m
-              memory: 2Gi
-            requests:
-              cpu: 1200m
-              memory: 1Gi
+        - image: quay.io/cloudservices/redis-ephemeral:6  
+          resources: {}


### PR DESCRIPTION
Kubernetes hated that the selector, which was removed, did not match the labels. So this brings back the selector.
Also some of the specifics in the assert did not match, so here I set the assert to what actually gets deployed. It could not be what we want, but at least this spells out what we are getting.